### PR TITLE
Add example usage sections to all remaining skills

### DIFF
--- a/content-ops/README.md
+++ b/content-ops/README.md
@@ -96,3 +96,11 @@ age_multiplier: <6mo = 0.5, 6-12mo = 1.0, 12-24mo = 1.5, >24mo = 2.0
 - WordPress / Webflow (published content scanning)
 - Grammarly API (supplementary readability data)
 - Slack (decay alerts, panel notifications)
+
+## Example Usage
+
+```
+> "Score this blog draft with the expert panel and check readability"
+> "Show content decay report — what needs refreshing this month?"
+> "Extract reusable atoms from our latest whitepaper"
+```

--- a/conversion-ops/README.md
+++ b/conversion-ops/README.md
@@ -100,3 +100,11 @@ Target: total friction < 35
 - Screaming Frog / Playwright (competitor crawling)
 - Figma (annotated screenshot exports)
 - Slack (audit result notifications)
+
+## Example Usage
+
+```
+> "Audit acme.com/pricing for conversion optimization"
+> "Map the micro-conversion funnel and find the biggest drop-off"
+> "Score our landing page against Cialdini's 6 persuasion principles"
+```

--- a/finance-ops/README.md
+++ b/finance-ops/README.md
@@ -109,3 +109,11 @@ Constraint: no single channel > 40% of total budget (diversification)
 - HubSpot / Salesforce (deal and customer acquisition data)
 - Google Sheets (manual data import/export)
 - Slack (monthly digest, burn rate alerts)
+
+## Example Usage
+
+```
+> "Calculate LTV by cohort for the last 12 months"
+> "Show CAC and payback period by acquisition channel"
+> "Run a scenario analysis — what if churn drops 2% and ARPU grows 15%?"
+```

--- a/outbound-engine/README.md
+++ b/outbound-engine/README.md
@@ -99,3 +99,11 @@ Green: > 1.2x | Yellow: 0.8-1.2x | Red: < 0.8x
 - Google Postmaster Tools (domain reputation)
 - HubSpot / Salesforce (CRM sync)
 - Slack (reply alerts, performance digests)
+
+## Example Usage
+
+```
+> "Build a 5-step outbound sequence for VP Marketing at mid-market SaaS"
+> "Generate a 14-day warmup schedule for our new sending domain"
+> "A/B test these 3 subject lines on 10% of the list first"
+```

--- a/podcast-ops/README.md
+++ b/podcast-ops/README.md
@@ -112,3 +112,11 @@ Host-read mid-roll: CPM * 2.5
 - Canva API (audiogram and quote card generation)
 - Slack (episode processing alerts, guest pipeline updates)
 - Google Sheets (guest tracking, sponsorship CRM)
+
+## Example Usage
+
+```
+> "Score these 10 guest candidates for our AI marketing series"
+> "Calculate our sponsorship rate card based on current download numbers"
+> "Extract the top 10 shareable clips from this week's episode"
+```

--- a/sales-playbook/README.md
+++ b/sales-playbook/README.md
@@ -128,3 +128,11 @@ timeline_alignment: contract ending soon (10), mid-contract (5), recently renewe
 - G2 / Capterra (competitor review intelligence)
 - Slack (deal alerts, weekly review notifications)
 - Google Sheets (ROI model sharing, benchmark data)
+
+## Example Usage
+
+```
+> "Qualify this deal using MEDDPICC + BANT and show the gaps"
+> "Build an ROI model for Acme Corp with 3-year NPV projection"
+> "Create a competitive displacement playbook for replacing Competitor X"
+```

--- a/seo-ops/README.md
+++ b/seo-ops/README.md
@@ -119,3 +119,11 @@ format_modifier: content matches feature format = 2.0, partial = 1.0, mismatch =
 - Clearscope / Surfer SEO (content optimization)
 - Google PageSpeed Insights (Core Web Vitals)
 - Slack (weekly brief delivery, alert notifications)
+
+## Example Usage
+
+```
+> "Run an SEO audit for acme.com and score keyword opportunities"
+> "Build content clusters for 'marketing automation' with a pillar page plan"
+> "Check for keyword cannibalization across our blog"
+```

--- a/team-ops/README.md
+++ b/team-ops/README.md
@@ -122,3 +122,11 @@ Unhealthy: carryover > 35% OR velocity declining 2+ consecutive sprints
 - Slack (weekly digests, capacity alerts, meeting summaries)
 - Google Sheets (skills matrix, OKR tracking)
 - Lattice / 15Five (performance review data)
+
+## Example Usage
+
+```
+> "Generate 1:1 prep doc for my meeting with Sarah tomorrow"
+> "Show team capacity forecast for the next 4 weeks"
+> "Run a skills gap analysis and recommend hire vs train vs outsource"
+```


### PR DESCRIPTION
Closes #4

Adds Example Usage sections with 3 practical natural language commands to each remaining skill: Content, Conversion, Outbound Engine, SEO, Finance, Podcast, Team, and Sales Playbook.