### PR TITLE
ci: add Python tests workflow running unittest on 3.10/3.11/3.12

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,26 @@
+name: tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  unittest:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Compile-check Python files
+        run: |
+          python -m compileall -q python_runtime tests examples
+      - name: Run unit tests
+        run: python -m unittest discover -v


### PR DESCRIPTION
Adds a GitHub Actions workflow that compile-checks python_runtime/tests/examples and runs unittest discovery on Python 3.10, 3.11, and 3.12.