### PR TITLE
docs: add hero image to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 <div align="center">
 
+<img src="assets/hero.svg" alt="AI Marketing Claude Skills — 12 marketing-ops skills with scoring algorithms and statistical frameworks" width="100%"/>
+
 # 🎯 AI Marketing Claude Skills
 
 ### AI-Powered Marketing Skills to Automate Operations and Drive Measurable ROI

--- a/assets/hero.svg
+++ b/assets/hero.svg
@@ -1,0 +1,92 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 380" role="img" aria-label="AI Marketing Claude Skills. 12 marketing-ops skills with scoring algorithms and statistical frameworks.">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1a0a22"/>
+      <stop offset="50%" style="stop-color:#33133f"/>
+      <stop offset="100%" style="stop-color:#1a0a22"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#f472b6"/>
+      <stop offset="100%" style="stop-color:#a855f7"/>
+    </linearGradient>
+    <linearGradient id="sales" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#ff8e72"/>
+      <stop offset="100%" style="stop-color:#ff6b6b"/>
+    </linearGradient>
+    <linearGradient id="growth" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#4ecdc4"/>
+      <stop offset="100%" style="stop-color:#45b7aa"/>
+    </linearGradient>
+    <linearGradient id="ops" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#9b8fff"/>
+      <stop offset="100%" style="stop-color:#7c83fd"/>
+    </linearGradient>
+  </defs>
+
+  <rect width="1200" height="380" fill="url(#bg)" rx="12"/>
+
+  <ellipse cx="200" cy="190" rx="260" ry="160" fill="#f472b6" opacity="0.10"/>
+  <ellipse cx="1000" cy="190" rx="240" ry="140" fill="#4ecdc4" opacity="0.08"/>
+
+  <g opacity="0.05" stroke="#ffffff" stroke-width="0.5">
+    <line x1="0" y1="76" x2="1200" y2="76"/>
+    <line x1="0" y1="190" x2="1200" y2="190"/>
+    <line x1="0" y1="304" x2="1200" y2="304"/>
+  </g>
+
+  <rect x="80" y="42" width="80" height="3" rx="1.5" fill="url(#accent)"/>
+
+  <!-- Glyph: rising bar chart -->
+  <g transform="translate(80, 62)">
+    <rect width="56" height="56" rx="12" fill="#a855f7" opacity="0.18"/>
+    <rect x="12" y="36" width="8" height="12" rx="1" fill="#f472b6"/>
+    <rect x="24" y="28" width="8" height="20" rx="1" fill="#a855f7"/>
+    <rect x="36" y="18" width="8" height="30" rx="1" fill="#f472b6"/>
+    <path d="M12 16 L24 14 L36 10 L46 6" stroke="#4ecdc4" stroke-width="1.8" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+  </g>
+
+  <text x="156" y="100" font-family="-apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif" font-size="44" font-weight="800" fill="#ffffff" letter-spacing="-1">AI Marketing Claude Skills</text>
+
+  <text x="156" y="135" font-family="-apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif" font-size="18" font-weight="400" fill="#f5d6f0">12 battle-tested marketing-ops skills with scoring algorithms and statistical frameworks.</text>
+
+  <rect x="80" y="170" width="1040" height="1" fill="#ffffff" opacity="0.12"/>
+
+  <!-- Three track columns -->
+  <g transform="translate(80, 200)" font-family="-apple-system, sans-serif">
+    <!-- SALES & REVENUE -->
+    <g>
+      <rect width="330" height="140" rx="12" fill="url(#sales)" opacity="0.95"/>
+      <text x="20" y="32" font-size="12" font-weight="700" fill="#ffffff" letter-spacing="2">SALES &amp; REVENUE · 4</text>
+      <g font-size="13" font-weight="500" fill="#ffeae0">
+        <text x="20" y="60">· Sales Pipeline</text>
+        <text x="20" y="80">· Outbound Engine</text>
+        <text x="20" y="100">· Sales Playbook</text>
+        <text x="20" y="120">· Revenue Intelligence</text>
+      </g>
+    </g>
+
+    <!-- GROWTH & CONTENT -->
+    <g transform="translate(355, 0)">
+      <rect width="330" height="140" rx="12" fill="url(#growth)" opacity="0.95"/>
+      <text x="20" y="32" font-size="12" font-weight="700" fill="#ffffff" letter-spacing="2">GROWTH &amp; CONTENT · 5</text>
+      <g font-size="13" font-weight="500" fill="#dcfaf6">
+        <text x="20" y="58">· SEO · Conversion Ops</text>
+        <text x="20" y="78">· Growth Engine</text>
+        <text x="20" y="98">· Content Ops</text>
+        <text x="20" y="118">· Creative Ops</text>
+      </g>
+    </g>
+
+    <!-- OPERATIONS -->
+    <g transform="translate(710, 0)">
+      <rect width="330" height="140" rx="12" fill="url(#ops)"/>
+      <text x="20" y="32" font-size="12" font-weight="700" fill="#ffffff" letter-spacing="2">OPERATIONS · 3</text>
+      <g font-size="13" font-weight="500" fill="#e8e4ff">
+        <text x="20" y="60">· Finance Ops</text>
+        <text x="20" y="80">· Podcast Ops</text>
+        <text x="20" y="100">· Team Ops</text>
+        <text x="20" y="120" opacity="0.75">Cross-functional support layer</text>
+      </g>
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
Adds a 1200x380 SVG hero banner to `assets/hero.svg` and references it at the top of the README, matching the styling already used in sibling repos (`ai-pm-agents-suite`, `ai-gtm-skill-library`, `claude-code-skills`).

**Subject:** 12 marketing-ops skills across Sales & Revenue, Growth & Content, and Operations tracks

### Changes
- Commit 1 - `assets: add hero.svg` - drops in the new SVG asset
- Commit 2 - `docs(readme): show hero.svg banner at the top of the README` - adds the `<img>` reference inside the existing centered intro block

No code changes. README-only above the title plus one new SVG asset.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>